### PR TITLE
Revert "Bump org.apache.commons:commons-compress from 1.21 to 1.26.0 in /docx4j-core"

### DIFF
--- a/docx4j-core/pom.xml
+++ b/docx4j-core/pom.xml
@@ -265,7 +265,7 @@
 		<dependency>
 		    <groupId>org.apache.commons</groupId>
 		    <artifactId>commons-compress</artifactId>
-		    <version>1.26.0</version>
+		    <version>1.21</version>
 		</dependency>		 
 		 
 		 <!--  supports org.apache.commons.lang.NotImplementedException -->


### PR DESCRIPTION
Reverts LegalSifter/docx4j#12