### PR TITLE
[RPP-6640] - Dependabot: docx4j [High] Jul 23, 2026: jackson-databind has a PolymorphicTypeValidator bypass via generic type parameters that allows arbitrary class instantiation

### DIFF
--- a/docx4j-legacy-service/pom.xml
+++ b/docx4j-legacy-service/pom.xml
@@ -91,8 +91,8 @@
 		<dependency>
 		  <groupId>com.fasterxml.jackson.core</groupId>
 		  <artifactId>jackson-databind</artifactId>
-			<version>2.12.7.1</version>
-		</dependency>		
+			<version>2.18.9</version>
+		</dependency>
     		 
 	</dependencies>
 	


### PR DESCRIPTION
Resolves [RPP-6640](https://legalsifter.atlassian.net/browse/RPP-6640), [RPP-6641](https://legalsifter.atlassian.net/browse/RPP-6641), [RPP-6639](https://legalsifter.atlassian.net/browse/RPP-6639), [RPP-6642](https://legalsifter.atlassian.net/browse/RPP-6642) and [RPP-6643](https://legalsifter.atlassian.net/browse/RPP-6643) — all five open jackson-databind Dependabot alerts on this repo (alerts 18–22, same dependency in the same pom).

Bumps `com.fasterxml.jackson.core:jackson-databind` 2.12.7.1 → 2.18.9 in `docx4j-legacy-service/pom.xml`:

- GHSA-j3rv-43j4-c7qm (High, PolymorphicTypeValidator bypass via generic type parameters; first patched 2.18.8) — RPP-6640
- GHSA-rmj7-2vxq-3g9f (High, array subtype allowlist bypass in BasicPolymorphicTypeValidator; first patched 2.18.8) — RPP-6641
- GHSA-3wrr-7qpf-2prh (Moderate, StackOverflowError on deeply nested JsonNode toString(); first patched 2.14.0) — RPP-6639
- GHSA-5jmj-h7xm-6q6v (Moderate, case-insensitive deserialization bypasses per-property @JsonIgnoreProperties; first patched 2.18.9) — RPP-6642
- GHSA-hgj6-7826-r7m5 (Moderate, InetSocketAddress deserialization triggers eager DNS resolution / SSRF; first patched 2.18.8) — RPP-6643

2.18.9 is the minimal version covering all five advisories. `jackson-core` stays at its existing 2.18.6 pin (same 2.18 minor line; resolved tree is coherent: core 2.18.6, databind 2.18.9, annotations 2.18.9).

Verification: root reactor `mvn clean install` builds green; `docx4j-legacy-service` compiles cleanly against 2.18.9 (its only databind consumer is `JsonUtil`, which uses stable `ObjectMapper`/`JsonNode` APIs). Note this module is commented out of the reactor, so CI never builds it; its standalone build fails on the old maven-enforcer bytecode rule both before and after this change (pre-existing, confirmed with a control build on the original pom), so verification ran with `-Denforcer.skip=true`.

[RPP-6640]: https://legalsifter.atlassian.net/browse/RPP-6640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RPP-6641]: https://legalsifter.atlassian.net/browse/RPP-6641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RPP-6639]: https://legalsifter.atlassian.net/browse/RPP-6639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RPP-6642]: https://legalsifter.atlassian.net/browse/RPP-6642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RPP-6643]: https://legalsifter.atlassian.net/browse/RPP-6643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ